### PR TITLE
ENH: renders heatmaps

### DIFF
--- a/altair_matplotlib/core.py
+++ b/altair_matplotlib/core.py
@@ -2,6 +2,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import pandas as pd
 import altair
+import seaborn as sns
 
 from . import utils
 
@@ -48,8 +49,24 @@ def _defined_traits(obj):
 def _render_chart(chart):
     if chart.mark == 'line':
         return _render_line_chart(chart)
+    elif chart.mark == 'text' and 'color' in chart.to_dict()['encoding']:
+        return _render_heatmap(chart)
     else:
         raise NotImplementedError("mark = {0}".format(chart.mark))
+
+
+def _render_heatmap(chart):
+    data = utils.chart_data(chart)
+    encoding = chart.to_dict()['encoding']
+    column, row, color = [encoding[key]['field']
+                         for key in ['column', 'row', 'color']]
+    if encoding['text']['field'] not in {None, ' ', ''}:
+        kwargs = {'annot': True}
+    else:
+        kwargs = {'annot': False}
+
+    data = data.pivot_table(columns=column, index=row, values=color)
+    return sns.heatmap(data, **kwargs)
 
 
 def _render_line_chart(chart):

--- a/altair_matplotlib/tests/test_heatmap.py
+++ b/altair_matplotlib/tests/test_heatmap.py
@@ -1,0 +1,19 @@
+from altair import Chart, load_dataset
+from altair_matplotlib import render
+import matplotlib.pyplot as plt
+
+
+def test_heatmap(show=False):
+    """ A visual check that the heatmap looks appropriate """
+    df = load_dataset('cars')
+
+    c = Chart(df).mark_text().encode(
+            row='Origin', column='Cylinders', text='Horsepower', color='Horsepower'
+        )
+
+    render(c)
+    if show:
+        plt.show()
+
+if __name__ == "__main__":
+    test_heatmap(show=True)


### PR DESCRIPTION
This PR addresses plots I create frequently, using `mark_text(applyColorToBackground=True)` and `color` to show a heatmap. This provides a basic implementation of heatmap rendering (I didn't want to sink to much time).

I tried to implement some tests but they require human feedback to verify the plots match.

I appreciate this repo -- I've often wished to view Altair plots from the command line. I've only wanted to view the plain Altair plot (like the one displayed in the notebook). I don't see any downside to exporting an Altair chart to an PNG than displaying that PNG with matplotlib.

---

From this heatmap...
<img width="492" alt="screen shot 2016-11-04 at 10 51 05 pm" src="https://cloud.githubusercontent.com/assets/1320475/20027388/33fe69f2-a2e1-11e6-8760-ffdb381a7394.png">

...I generated
<img width="292" alt="screen shot 2016-11-04 at 10 51 05 pm" src="https://cloud.githubusercontent.com/assets/1320475/20027387/33ea0eb2-a2e1-11e6-80c2-e4f1ebd1ec79.png">



